### PR TITLE
Prevent duplicate registration

### DIFF
--- a/nn_cli.c
+++ b/nn_cli.c
@@ -122,7 +122,7 @@ static NNCli_Err_t GetInputAsync(char **out_string)
     /* Asynchronous mode using the multiplexing API: wait for
      * data on stdin, and simulate async data coming from some source
      * using the select(2) timeout. */
-    NNCli_Err_t ret = NN_CLI_IN_PROGRESS;
+    NNCli_Err_t ret = NN_CLI__IN_PROGRESS;
     static bool s_requires_init = true;
     static struct linenoiseState ls;
     static char buf[1024];
@@ -437,7 +437,7 @@ NNCli_Err_t NNCli_Run(void)
     if (s_async.m_enabled)
     {
         NNCli_Err_t ret_async = GetInputAsync(&line);
-        if (ret_async == NN_CLI_IN_PROGRESS)
+        if (ret_async == NN_CLI__IN_PROGRESS)
         {
             goto done;
         }

--- a/nn_cli.c
+++ b/nn_cli.c
@@ -331,6 +331,16 @@ NNCli_Err_t NNCli_RegisterCommand(const NNCli_Command_t *a_cmd)
         goto done;
     }
 
+    for (size_t i = 0; i < s_command_list.m_num; i++)
+    {
+        if (strcmp(s_command_list.m_command[i]->m_name, a_cmd->m_name) == 0)
+        {
+            NNCli_LogError("%s command is already registered", a_cmd->m_name);
+            res = NN_CLI__DUPLICATE;
+            goto done;
+        }
+    }
+
     s_command_list.m_command[s_command_list.m_num] = a_cmd;
     s_command_list.m_num++;
 

--- a/nn_cli.h
+++ b/nn_cli.h
@@ -10,8 +10,8 @@ typedef enum
     NN_CLI__INVALID_ARGS,       // Input arguments are incorrect.
     NN_CLI__EXCEED_CAPACITY,    // The size limit for arrays, etc. has been reached.
     NN_CLI__EXTERNAL_LIB_ERROR, // Errors in external libraries or tools used
-    NN_CLI__PROCESS_COMPLETED,  // This indicates that the process has been completed, but it may have been completed successfully.
-    NN_CLI_IN_PROGRESS,         // It means that the process is in progress internally. This may not always be an error.
+    NN_CLI__PROCESS_COMPLETED,  // It means that the process has been completed, but it may have been completed successfully.
+    NN_CLI__IN_PROGRESS,        // It means that the process is in progress internally. This may not always be an error.
     NN_CLI__DUPLICATE           // It means that the data is duplicated.
 } NNCli_Err_t;
 

--- a/nn_cli.h
+++ b/nn_cli.h
@@ -12,6 +12,7 @@ typedef enum
     NN_CLI__EXTERNAL_LIB_ERROR, // Errors in external libraries or tools used
     NN_CLI__PROCESS_COMPLETED,  // This indicates that the process has been completed, but it may have been completed successfully.
     NN_CLI_IN_PROGRESS,         // It means that the process is in progress internally. This may not always be an error.
+    NN_CLI__DUPLICATE           // It means that the data is duplicated.
 } NNCli_Err_t;
 
 typedef NNCli_Err_t (*NNCli_Func_t)(int argc, char **argv);

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -129,7 +129,7 @@ namespace testing
         ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__EXCEED_CAPACITY);
     }
 
-    TEST_F(NNCliTest, NNCliTest_RegisterCommand_InvalidArgs)
+    TEST_F(NNCliTest, RegisterCommand_InvalidArgs)
     {
         ASSERT_EQ(NNCli_RegisterCommand(nullptr), NN_CLI__INVALID_ARGS);
 
@@ -150,7 +150,7 @@ namespace testing
         ASSERT_EQ(NNCli_RegisterCommand(&no_name_cmd), NN_CLI__INVALID_ARGS);
     }
 
-    TEST_F(NNCliTest, NNCliTest_RegisterCommand_PreventDuplicate)
+    TEST_F(NNCliTest, RegisterCommand_PreventDuplicate)
     {
         constexpr NNCli_Command_t cmd = {
             .m_func = TestCmdFunc,

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -129,27 +129,6 @@ namespace testing
         ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__EXCEED_CAPACITY);
     }
 
-    TEST_F(NNCliTest, RegisterCommand_InvalidArgs)
-    {
-        ASSERT_EQ(NNCli_RegisterCommand(nullptr), NN_CLI__INVALID_ARGS);
-
-        constexpr NNCli_Command_t no_func_cmd = {
-            .m_func = nullptr,
-            .m_name = "test-cmd",
-            .m_options = "on/off",
-            .m_help_msg = "test help msg",
-        };
-        ASSERT_EQ(NNCli_RegisterCommand(&no_func_cmd), NN_CLI__INVALID_ARGS);
-
-        constexpr NNCli_Command_t no_name_cmd = {
-            .m_func = TestCmdFunc,
-            .m_name = "",
-            .m_options = "on/off",
-            .m_help_msg = "test help msg",
-        };
-        ASSERT_EQ(NNCli_RegisterCommand(&no_name_cmd), NN_CLI__INVALID_ARGS);
-    }
-
     TEST_F(NNCliTest, RegisterCommand_PreventDuplicate)
     {
         constexpr NNCli_Command_t cmd = {

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -139,6 +139,19 @@ namespace testing
         ASSERT_EQ(NNCli_RegisterCommand(&no_name_cmd), NN_CLI__INVALID_ARGS);
     }
 
+    TEST_F(NNCliTest, NNCliTest_RegisterCommand_PreventDuplicate)
+    {
+        constexpr NNCli_Command_t cmd = {
+            .m_func = TestCmdFunc,
+            .m_name = "test-cmd",
+            .m_options = "on/off",
+            .m_help_msg = "test help msg",
+        };
+
+        ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__SUCCESS);
+        ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__DUPLICATE);
+    }
+
     TEST_F(NNCliTest, Init_Success)
     {
         char filename[] = "/tmp/nncli_test_history_XXXXXX";

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -73,7 +73,7 @@ namespace testing
 
         constexpr NNCli_Command_t no_option_cmd = {
             .m_func = TestCmdFunc,
-            .m_name = "test-cmd",
+            .m_name = "no-option-test-cmd",
             .m_options = nullptr,
             .m_help_msg = "test help msg",
         };
@@ -103,18 +103,29 @@ namespace testing
 
     TEST_F(NNCliTest, RegisterCommand_upperLimit)
     {
-        constexpr NNCli_Command_t cmd = {
-            .m_func = TestCmdFunc,
-            .m_name = "test-cmd",
-            .m_options = "on/off",
-            .m_help_msg = "test help msg",
-        };
+        NNCli_Command_t cmds[NN_CLI__MAX_COMMAND_NUM];
+        std::string cmd_names[NN_CLI__MAX_COMMAND_NUM];
 
         for (int i = 0; i < NN_CLI__MAX_COMMAND_NUM; i++)
         {
-            ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__SUCCESS);
+            cmd_names[i] = "test-cmd" + std::to_string(i);
+            NNCli_Command_t cmd = {
+                .m_func = TestCmdFunc,
+                .m_name = cmd_names[i].c_str(),
+                .m_options = "on/off",
+                .m_help_msg = "test help msg",
+            };
+            cmds[i] = cmd;
+
+            ASSERT_EQ(NNCli_RegisterCommand(&cmds[i]), NN_CLI__SUCCESS);
         }
 
+        constexpr NNCli_Command_t cmd = {
+            .m_func = TestCmdFunc,
+            .m_name = "upper-limit-test-cmd",
+            .m_options = "on/off",
+            .m_help_msg = "test help msg",
+        };
         ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__EXCEED_CAPACITY);
     }
 

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -62,7 +62,7 @@ namespace testing
 {
     TEST_F(NNCliTest, RegisterCommand_Success)
     {
-        constexpr NNCli_Command_t cmd = {
+        const NNCli_Command_t cmd = {
             .m_func = TestCmdFunc,
             .m_name = "test-cmd",
             .m_options = "on/off",
@@ -71,7 +71,7 @@ namespace testing
 
         ASSERT_EQ(NNCli_RegisterCommand(&cmd), NN_CLI__SUCCESS);
 
-        constexpr NNCli_Command_t no_option_cmd = {
+        const NNCli_Command_t no_option_cmd = {
             .m_func = TestCmdFunc,
             .m_name = "no-option-test-cmd",
             .m_options = nullptr,
@@ -84,7 +84,7 @@ namespace testing
     {
         ASSERT_EQ(NNCli_RegisterCommand(nullptr), NN_CLI__INVALID_ARGS);
 
-        constexpr NNCli_Command_t no_func_cmd = {
+        const NNCli_Command_t no_func_cmd = {
             .m_func = nullptr,
             .m_name = "test-cmd",
             .m_options = "on/off",
@@ -92,7 +92,7 @@ namespace testing
         };
         ASSERT_EQ(NNCli_RegisterCommand(&no_func_cmd), NN_CLI__INVALID_ARGS);
 
-        constexpr NNCli_Command_t no_name_cmd = {
+        const NNCli_Command_t no_name_cmd = {
             .m_func = TestCmdFunc,
             .m_name = "",
             .m_options = "on/off",
@@ -120,7 +120,7 @@ namespace testing
             ASSERT_EQ(NNCli_RegisterCommand(&cmds[i]), NN_CLI__SUCCESS);
         }
 
-        constexpr NNCli_Command_t cmd = {
+        const NNCli_Command_t cmd = {
             .m_func = TestCmdFunc,
             .m_name = "upper-limit-test-cmd",
             .m_options = "on/off",
@@ -131,7 +131,7 @@ namespace testing
 
     TEST_F(NNCliTest, RegisterCommand_PreventDuplicate)
     {
-        constexpr NNCli_Command_t cmd = {
+        const NNCli_Command_t cmd = {
             .m_func = TestCmdFunc,
             .m_name = "test-cmd",
             .m_options = "on/off",
@@ -182,7 +182,7 @@ namespace testing
     TEST_F(NNCliTest, Run_Success)
     {
 
-        constexpr NNCli_Command_t cmd = {
+        const NNCli_Command_t cmd = {
             .m_func = TestCmdFunc,
             .m_name = "test-cmd",
             .m_options = "on/off",


### PR DESCRIPTION
Added a new feature to the `NNCli_RegisterCommand` function that checks if the command is registered twice.
In addition, a unit test is added to check the feature.

#19 