### PR TITLE
AA returns an error if not ready

### DIFF
--- a/nn_cli.c
+++ b/nn_cli.c
@@ -474,22 +474,21 @@ done:
  * linenoise, so the user needs to free() it. */
 NNCli_Err_t NNCli_Run(void)
 {
-    NNCli_Err_t err = NN_CLI__SUCCESS;
+    NNCli_Err_t err;
     char *line;
     if (s_async.m_enabled)
     {
-        NNCli_Err_t ret_async = GetInputAsync(&line);
-        if (ret_async == NN_CLI__IN_PROGRESS)
+        err = GetInputAsync(&line);
+        if (err != NN_CLI__SUCCESS)
         {
             goto done;
         }
     }
     else
     {
-        NNCli_Err_t ret_sync = GetInputSync(&line);
-        if (ret_sync != NN_CLI__SUCCESS)
+        err = GetInputSync(&line);
+        if (err != NN_CLI__SUCCESS)
         {
-            err = ret_sync;
             goto done;
         }
     }

--- a/nn_cli.c
+++ b/nn_cli.c
@@ -342,10 +342,10 @@ static bool CheckOrCreateFile(const char *filename)
     return true;
 }
 
+static bool IsInitialized(void) { return s_command_list.m_num > 0; }
+
 /**
- *
  * Public functions
- *
  */
 
 NNCli_Err_t NNCli_RegisterCommand(const NNCli_Command_t *a_cmd)
@@ -474,8 +474,14 @@ done:
  * linenoise, so the user needs to free() it. */
 NNCli_Err_t NNCli_Run(void)
 {
-    NNCli_Err_t err;
+    NNCli_Err_t err = NN_CLI__NOT_READY;
     char *line;
+    if (!IsInitialized())
+    {
+        NNCli_LogError("NNCli is not initialized");
+        goto done;
+    }
+
     if (s_async.m_enabled)
     {
         err = GetInputAsync(&line);

--- a/nn_cli.h
+++ b/nn_cli.h
@@ -16,7 +16,8 @@ typedef enum
                                 // but it may have been completed successfully.
     NN_CLI__IN_PROGRESS,        // It means that the process is in progress
                                 // internally. This may not always be an error.
-    NN_CLI__DUPLICATE           // It means that the data is duplicated.
+    NN_CLI__DUPLICATE,          // It means that the data is duplicated.
+    NN_CLI__NOT_READY,          // The function or module is not ready yet.
 } NNCli_Err_t;
 
 typedef NNCli_Err_t (*NNCli_Func_t)(int argc, char **argv);

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -206,4 +206,7 @@ TEST_F(NNCliTest, Run_Success)
     DummyKeyboardInput("help\n");
     ASSERT_EQ(NNCli_Run(), NN_CLI__SUCCESS);
 }
+
+TEST_F(NNCliTest, Run_BeforeInit) { ASSERT_EQ(NNCli_Run(), NN_CLI__NOT_READY); }
+
 }  // namespace testing


### PR DESCRIPTION
Currently, if the NNCli_Run function is called before the NNCli_Init function, it does not return an appropriate error.
And we added unit tests to validate it.

#30 