### PR TITLE
Prevent `NNCli_Init()` from being called twice

### DIFF
--- a/nn_cli.c
+++ b/nn_cli.c
@@ -43,6 +43,7 @@ typedef struct
 static NNCli_AsyncOption_t s_async;
 static CommandList_t s_command_list;
 static char *s_history_filename;
+static bool s_is_initialized = false;
 
 static void completion(const char *buf, linenoiseCompletions *lc)
 {
@@ -342,7 +343,7 @@ static bool CheckOrCreateFile(const char *filename)
     return true;
 }
 
-static bool IsInitialized(void) { return s_command_list.m_num > 0; }
+static bool IsInitialized(void) { return s_is_initialized; }
 
 /**
  * Public functions
@@ -388,7 +389,13 @@ done:
 
 NNCli_Err_t NNCli_Init(const NNCli_Option_t *a_option)
 {
-    NNCli_Err_t res = NN_CLI__INVALID_ARGS;
+    NNCli_Err_t res = NN_CLI__IN_PROGRESS;
+    if (IsInitialized())
+    {
+        goto done;
+    }
+
+    res = NN_CLI__INVALID_ARGS;
     if (a_option == NULL)
     {
         NNCli_LogError("a_option is NULL");
@@ -461,6 +468,7 @@ NNCli_Err_t NNCli_Init(const NNCli_Option_t *a_option)
     linenoiseSetCompletionCallback(completion);
     linenoiseSetHintsCallback(hints);
 
+    s_is_initialized = true;
     res = NN_CLI__SUCCESS;
 
 done:

--- a/nn_cli.c
+++ b/nn_cli.c
@@ -431,6 +431,8 @@ NNCli_Err_t NNCli_Init(const NNCli_Option_t *a_option)
         s_async = a_option->m_async;
     }
 
+    NNCli_AssertOrReturn(s_history_filename == NULL, NN_CLI__GENERAL_ERROR,
+                         "s_history_filename is not NULL");
     // This is not released by free() until the end, because it is used to save
     // the command each time.
     s_history_filename =

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -221,6 +221,28 @@ TEST_F(NNCliTest, Init_InvalidArgs)
     ASSERT_EQ(NNCli_Init(&option), NN_CLI__INVALID_ARGS);
 }
 
+TEST_F(NNCliTest, Init_CallTwice)
+{
+    char filename[] = "/tmp/nncli_test_history_XXXXXX";
+    GenerateDummyHistoryFile(filename);
+    const NNCli_Option_t option = {
+        .m_enable_multi_line = true,
+        .m_show_key_codes = false,
+        .m_async =
+            {
+                .m_enabled = false,
+                .m_timeout = {.tv_sec = 0, .tv_usec = 0},
+            },
+        .m_history_filename = filename,
+    };
+
+    ASSERT_EQ(NNCli_Init(&option), NN_CLI__SUCCESS);
+    free(s_history_filename);
+    s_history_filename = nullptr;
+
+    ASSERT_EQ(NNCli_Init(&option), NN_CLI__IN_PROGRESS);
+}
+
 TEST_F(NNCliTest, Run_Success)
 {
     const NNCli_Command_t cmd = {

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -55,6 +55,11 @@ class NNCliTest : public ::testing::Test
     {
         s_async = {0};
         s_command_list = {0};
+        if (s_history_filename != nullptr)
+        {
+            free(s_history_filename);
+            s_history_filename = nullptr;
+        }
     }
 };
 
@@ -198,7 +203,6 @@ TEST_F(NNCliTest, Init_Success)
     };
 
     ASSERT_EQ(NNCli_Init(&option), NN_CLI__SUCCESS);
-    free(s_history_filename);
 }
 
 TEST_F(NNCliTest, Init_InvalidArgs)

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -55,6 +55,7 @@ class NNCliTest : public ::testing::Test
     {
         s_async = {0};
         s_command_list = {0};
+        s_is_initialized = false;
         if (s_history_filename != nullptr)
         {
             free(s_history_filename);


### PR DESCRIPTION
Returns `NN_CLI__IN_PROGRESS` if `NNCli_Init()` is called twice.
Add a flag to control that `NNCli_Init()` has already been called.
Use free() in TearDown() to free the pointer.

#33 