### PR TITLE
Add the function to check command length

### DIFF
--- a/nn_cli.c
+++ b/nn_cli.c
@@ -107,12 +107,21 @@ static NNCli_Err_t SplitStringWithSpace(const char *a_raw_command,
                          "out_tokens is NULL");
 
     static char strCopy[COMMAND_STRING_MAX_LEN];
-    strncpy(strCopy, a_raw_command, sizeof(strCopy) - 1);
-    strCopy[sizeof(strCopy) - 1] = '\0';
-
     int token_count = 0;
     char *context = NULL;
-    char *token = strtok_r(strCopy, " ", &context);
+    char *token;
+
+    if (strlen(a_raw_command) > COMMAND_STRING_MAX_LEN - 1)
+    {
+        NNCli_LogError(
+            "The length of the command exceeds the maximum limit: %d",
+            COMMAND_STRING_MAX_LEN);
+        res = NN_CLI__EXCEED_CAPACITY;
+        goto done;
+    }
+    strncpy(strCopy, a_raw_command, sizeof(strCopy) - 1);
+    strCopy[sizeof(strCopy) - 1] = '\0';
+    token = strtok_r(strCopy, " ", &context);
 
     while (token != NULL)
     {

--- a/nn_cli.c
+++ b/nn_cli.c
@@ -106,7 +106,7 @@ static NNCli_Err_t SplitStringWithSpace(const char *a_raw_command,
     NNCli_AssertOrReturn(out_tokens, NN_CLI__INVALID_ARGS,
                          "out_tokens is NULL");
 
-    static char strCopy[COMMAND_STRING_MAX_LEN];
+    static char str_copy[COMMAND_STRING_MAX_LEN];
     int token_count = 0;
     char *context = NULL;
     char *token;
@@ -119,9 +119,9 @@ static NNCli_Err_t SplitStringWithSpace(const char *a_raw_command,
         res = NN_CLI__EXCEED_CAPACITY;
         goto done;
     }
-    strncpy(strCopy, a_raw_command, sizeof(strCopy) - 1);
-    strCopy[sizeof(strCopy) - 1] = '\0';
-    token = strtok_r(strCopy, " ", &context);
+    strncpy(str_copy, a_raw_command, sizeof(str_copy) - 1);
+    str_copy[sizeof(str_copy) - 1] = '\0';
+    token = strtok_r(str_copy, " ", &context);
 
     while (token != NULL)
     {

--- a/test/nn_cli_test.cpp
+++ b/test/nn_cli_test.cpp
@@ -276,7 +276,7 @@ TEST_F(NNCliTest, Run_Success)
 
 TEST_F(NNCliTest, Run_BeforeInit) { ASSERT_EQ(NNCli_Run(), NN_CLI__NOT_READY); }
 
-TEST_F(NNCliTest, Run_UpperLimitCommandLength)
+TEST_F(NNCliTest, Run_WordLimitPerCommand)
 {
     const NNCli_Command_t cmd = {
         .m_func = TestCmdFunc,


### PR DESCRIPTION
Add the function to check if the length of the command exceeds the definition.
Change to use `NNCli_Err_t` in `SplitStringWithSpace()` function for ease of use.
Add unit test.

#43